### PR TITLE
Fix build error due to CXX standard version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(CutelystQt5 REQUIRED)
 
 # Auto generate moc files
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 add_definitions(-DQT_NO_KEYWORDS)
 


### PR DESCRIPTION
Currently, libIME is widely using CXX 17 grammar. Including its header files will fail the building.

Of course, upgrading CXX standard version to 17 can solve it.